### PR TITLE
Make authentication environment variables available in docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Support for authentication environment variables.
+
 ## [0.1.1] - 2022-05-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ You do not have to create a dedicated token. Make sure to use the GitHub's defau
 **Optional** By default ZAP Docker container will fail with an [exit code](https://github.com/zaproxy/zaproxy/blob/7abbd57f6894c2abf4f1ed00fb95e99c34ef2e28/docker/zap-api-scan.py#L35),
 if it identifies any alerts. Set this option to `true` if you want to fail the status of the GitHub Scan if ZAP identifies any alerts during the scan.
 
+## Environment variables
+
+If set, the following [ZAP authentication environment variables](https://www.zaproxy.org/docs/authentication/handling-auth-yourself/#authentication-env-vars)
+will be copied into the docker container:
+
+- `ZAP_AUTH_HEADER_VALUE`
+- `ZAP_AUTH_HEADER`
+- `ZAP_AUTH_HEADER_SITE`
+
 ## Example usage
 
 ** Basic **

--- a/dist/index.js
+++ b/dist/index.js
@@ -3832,7 +3832,7 @@ async function run() {
         await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE ` +
             `-t ${docker_name} zap-api-scan.py -t ${target} -f ${format} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ async function run() {
         await exec.exec(`chmod a+w ${jsonReportName} ${mdReportName} ${htmlReportName}`);
 
         await exec.exec(`docker pull ${docker_name} -q`);
-        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" ` +
+        let command = (`docker run -v ${workspace}:/zap/wrk/:rw --network="host" -e ZAP_AUTH_HEADER -e ZAP_AUTH_HEADER_VALUE -e ZAP_AUTH_HEADER_SITE ` +
             `-t ${docker_name} zap-api-scan.py -t ${target} -f ${format} -J ${jsonReportName} -w ${mdReportName}  -r ${htmlReportName} ${cmdOptions}`);
 
         if (plugins.length !== 0) {


### PR DESCRIPTION
I noticed some [authentication environment variables](https://www.zaproxy.org/docs/authentication/handling-auth-yourself/#authentication-env-vars) in the ZAP documentation, but it looks like they can't be set in the current version of the Github Action. This PR would make those env vars available in the docker container.

According to the [Docker documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file), the `--env VAR` syntax reads the variable from the local environment. If it's not set in the local environment, it won't be set in the container either. This seems to me to be the simplest solution among the options Docker provides, and AFAICT doesn't log the token at any point.

I'm fairly new to ZAP, so let me know if there's already a better way to set the Authorization header, or if there's some other way this should be implemented instead of what I've proposed here. Thanks!