### PR TITLE
Correct branch name in workflow

### DIFF
--- a/.github/workflows/check-run.yml
+++ b/.github/workflows/check-run.yml
@@ -3,7 +3,7 @@ name: Check run
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
Rename the branch to `main` to match the actual name of the branch.