### PR TITLE
Enhance Action Inputs for Custom Report File Names

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,18 @@ inputs:
   target:
     description: 'Target URL'
     required: true
+  html_report_name: 
+    description: 'Name of the html report file'
+    required: false
+    default: 'report_html.html'
+  json_report_name:
+    description: 'Name of the json report file'
+    required: false
+    default: 'report_json.json'
+  md_report_name:
+    description: 'Name of the markdown report file'
+    required: false
+    default: 'report_md.md'
   format:
     description: 'Format openapi, soap or graphql'
     required: false

--- a/index.js
+++ b/index.js
@@ -3,11 +3,6 @@ const exec = require('@actions/exec');
 const common = require('@zaproxy/actions-common-scans');
 const _ = require('lodash');
 
-// Default file names
-let jsonReportName = 'report_json.json';
-let mdReportName = 'report_md.md';
-let htmlReportName = 'report_html.html';
-
 async function run() {
 
     try {
@@ -25,6 +20,9 @@ async function run() {
         let allowIssueWriting = core.getInput('allow_issue_writing');
         let artifactName = core.getInput('artifact_name');
         let createIssue = true;
+        let jsonReportName = core.getInput("json_report_name");
+        let mdReportName = core.getInput("md_report_name");
+        let htmlReportName = core.getInput("html_report_name");
 
         if (!(String(failAction).toLowerCase() === 'true' || String(failAction).toLowerCase() === 'false')) {
             console.log('[WARNING]: \'fail_action\' action input should be either \'true\' or \'false\'');


### PR DESCRIPTION
This pull request enhances the action's flexibility by adding customizable file names for HTML, JSON, and Markdown reports. Previously, default file names were hardcoded, limiting user customization. With these changes, users can specify their preferred file names through action inputs (html_report_name, json_report_name, md_report_name). This update aims to improve usability and adaptability for different workflow requirements.